### PR TITLE
Temporarily restore the old CDN address

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -77,7 +77,7 @@ theme_mode: # [light|dark]
 # will be added to all image (site avatar & posts' images) paths starting with '/'
 #
 # e.g. 'https://cdn.com'
-img_cdn:
+img_cdn: "https://chirpy-img.netlify.app"
 
 # the avatar on sidebar, support local or CORS resources
 avatar:


### PR DESCRIPTION
- 이미지가 깨져서 임시로 CDN 주소 사용. 
- 이후 이미지 전체 교체시 해당 정보 반영해 수정 